### PR TITLE
Refactor/confirmation mailer

### DIFF
--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,6 +1,6 @@
 class ConfirmationMailer < ApplicationMailer
   def confirmation_mail(feed)
     @feed = feed
-    mail to: @feed.author_email, subject: "投稿確認メール"
+    mail to: @feed.author_email, subject: "投稿確認メール" if @feed.present?
   end
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,7 +1,7 @@
 class ConfirmationMailer < ApplicationMailer
-  def confirmation_mail(confirmation)
-    @confirmation = confirmation
-    @user = User.find(confirmation.user_id)
+  def confirmation_mail(feed)
+    @feed = feed
+    @user = User.find(feed.user_id)
     mail to: @user.email, subject: "投稿確認メール"
   end
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,7 +1,6 @@
 class ConfirmationMailer < ApplicationMailer
   def confirmation_mail(feed)
     @feed = feed
-    @user = User.find(feed.user_id)
-    mail to: @user.email, subject: "投稿確認メール"
+    mail to: @feed.user.email, subject: "投稿確認メール"
   end
 end

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -1,6 +1,6 @@
 class ConfirmationMailer < ApplicationMailer
   def confirmation_mail(feed)
     @feed = feed
-    mail to: @feed.user.email, subject: "投稿確認メール"
+    mail to: @feed.author_email, subject: "投稿確認メール"
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -2,6 +2,7 @@ class Feed < ApplicationRecord
   validates :content, presence: true, length: {maximum: 500}
   mount_uploader :image, ImageUploader
   belongs_to :user
+  delegate :email, to: :user, prefix: :author, allow_nil: false
   has_many :favorites, dependent: :destroy
   has_many :favorite_users, through: :favorites, source: :user
 end

--- a/app/views/confirmation_mailer/confirmation_mail.html.erb
+++ b/app/views/confirmation_mailer/confirmation_mail.html.erb
@@ -2,6 +2,6 @@
 
 <h4>投稿内容の確認</h4>
 
-<p>image: <%= image_tag("#{@confirmation.image}") %></p>
+<p>image: <%= image_tag("#{@feed.image}") %></p>
 
-<p>content: <%= @confirmation.content %></p>
+<p>content: <%= @feed.content %></p>


### PR DESCRIPTION
下記の内容をRefactorしました。

- @Confirmationの廃止（@Feedと同一の内容なので、@Feedを使うべき）
- findではなく@FeedのAssociationを利用してuser.emailを取得
- Modelのdelegateを利用して、@feed.user.emailを@feed.author_emailで取得
- @Feedがnilの場合、メール送信処理を実行しない